### PR TITLE
商品購入後表示変更

### DIFF
--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -132,9 +132,11 @@
             <div class='item-img-content'>
               <%= link_to image_tag(product.image, class: "item-img"), product_path(product.id), method: :get %>
               <%# 商品が売れていればsold outを表示しましょう %>
+              <% if product.product_purchase.present? %>
               <div class='sold-out'>
                 <span>Sold Out!!</span>
               </div>
+              <% end %>
               <%# //商品が売れていればsold outを表示しましょう %>
             </div>
             <div class='item-info'>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -9,9 +9,11 @@
     <div class='item-img-content'>
       <%= image_tag @product.image,　class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @product.product_purchase.present? %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
       </div>
+      <% end %>
       <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">


### PR DESCRIPTION
# What
商品購入後の表示を変更

# Why
商品購入後の表示を変更させるため

# キャプチャ動画
商品購入前の表示
 https://gyazo.com/60054f1808761ebd0313c7a2b2d95e5f
商品購入後の表示
 https://gyazo.com/16b53ad304739f5962d9fee50abf30ff
商品詳細画面の画像
 https://gyazo.com/cb2956a203ba002f74378bcdc03f895d

LGTMを頂きましたが商品購入後の表示が未実装だった為レビューをお願いします。